### PR TITLE
Remove unused uchar and uutf libraries

### DIFF
--- a/src/dune
+++ b/src/dune
@@ -3,13 +3,13 @@
  (public_name uuseg)
  (wrapped false)
  (modules :standard \ uuseg_string)
- (libraries uchar uucp)
- (flags :standard -w -50-39-37-32))
+ (libraries uucp)
+ (flags :standard -w -50-39-37-32-27))
 
 (library
  (name uuseg_string)
  (public_name uuseg.string)
  (wrapped false)
  (modules uuseg_string)
- (libraries uuseg uutf)
+ (libraries uuseg)
  (flags :standard -w -50-39-37-32))


### PR DESCRIPTION
Both uchar and uutf had been removed in original non-dune code, so this change makes the dune file reflect the source code.

Testing: `opam install . --with-dev-setup --deps-only --with-test`, `dune build` and `dune runtest`